### PR TITLE
docs: 주요 개발 스택에 Shadcn 추가 및 사용 범위 명시

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 
 ### 주요 개발 스택
 
-| Category         | Package Name           | Version |
+| Category         | Package Name           | Version | 
 | ---------------- | ---------------------- | ------- |
 | Bundler          | Vite                   | 5.2.0   |
 | Runtime          | Node.js                | 20.11.1 |
@@ -88,6 +88,10 @@
 | Form Handling    | React Hook Form        | 7.51.2  |
 | Styling          | TailwindCSS            | 3.4.3   |
 | Skeleton Screens | React Loading Skeleton | 3.4.0   |
+| UI Components | Shadcn | Latest   |
+
+#### Notes
+ - __Shadcn:__ 최근 추가된 UI 구성 요소 라이브러리. 동영상 콘텐츠부터 사용할 예정
 
 # 프로젝트 상세
 


### PR DESCRIPTION
- Shadcn을 주요 개발 스택에 추가
- 동영상 콘텐츠 페이지부터 Shadcn 사용 시작
- 주요 개발 스택 문서에 최근 변경 사항을 Notes로 명확하게 표시